### PR TITLE
Feat: Chatbot APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "seed:run": "ts-node -r tsconfig-paths/register ./src/database/seeds/run-seed.ts"
   },
   "dependencies": {
+    "@golevelup/ts-jest": "^0.4.0",
     "@joaomoreno/unique-names-generator": "^5.1.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "seed:run": "ts-node -r tsconfig-paths/register ./src/database/seeds/run-seed.ts"
   },
   "dependencies": {
+    "@joaomoreno/unique-names-generator": "^5.1.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",

--- a/src/api/bot/bot.controller.spec.ts
+++ b/src/api/bot/bot.controller.spec.ts
@@ -1,0 +1,77 @@
+import { Test } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+
+import { BotService } from './bot.service';
+import { BotController } from './bot.controller';
+import { CreateBotDto, CreatedBotDto } from './dto';
+
+import type { DeepMocked } from '@golevelup/ts-jest';
+
+describe('BotController', () => {
+  let botController: BotController;
+  let botService: DeepMocked<BotService>;
+
+  const bots: CreatedBotDto[] = [
+    {
+      id: '123',
+      name: 'test bot 1',
+      publishDate: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: '456',
+      name: 'test bot 2',
+      publishDate: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [BotController],
+    })
+      .useMocker(createMock)
+      .compile();
+
+    botService = module.get(BotService);
+    botController = module.get(BotController);
+  });
+
+  describe('createOne', () => {
+    it('should create a bot', async () => {
+      botService.create.mockResolvedValueOnce(bots[0]);
+
+      const data: CreateBotDto = { creatorId: '123' };
+
+      const result = await botController.createOne(data);
+
+      expect(result).toEqual(bots[0]);
+      expect(botService.create).toHaveBeenCalled();
+      expect(botService.create.mock.calls[0][0]).toEqual(data);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should get all bots of user', async () => {
+      botService.getAll.mockResolvedValueOnce(bots);
+
+      const result = await botController.getAll('123');
+
+      expect(result).toEqual(bots);
+      expect(botService.getAll).toHaveBeenCalled();
+      expect(botService.getAll.mock.calls[0][0]).toEqual('123');
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should delete the bot by id', async () => {
+      const result = await botController.deleteById('123');
+
+      expect(result).toEqual('123');
+      expect(botService.deleteById).toHaveBeenCalled();
+      expect(botService.deleteById.mock.calls[0][0]).toEqual('123');
+    });
+  });
+});

--- a/src/api/bot/bot.controller.ts
+++ b/src/api/bot/bot.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Param } from '@nestjs/common';
+
+import { InjectController, InjectRoute } from '@/decorators';
+
+import botRoutes from './bot.routes';
+import { BotService } from './bot.service';
+import { CreateBotDto, GotBotDto, CreatedBotDto } from './dto';
+
+@InjectController({ name: botRoutes.index })
+export class BotController {
+  constructor(private readonly botService: BotService) {}
+
+  @InjectRoute(botRoutes.create)
+  public async createOne(@Body() data: CreateBotDto): Promise<CreatedBotDto> {
+    const createdBot = await this.botService.create(data);
+
+    return createdBot;
+  }
+
+  @InjectRoute(botRoutes.getAll)
+  public async getAll(@Param('userId') userId: string): Promise<GotBotDto[]> {
+    const gotBots = await this.botService.getAll(userId);
+
+    return gotBots;
+  }
+
+  @InjectRoute(botRoutes.deleteById)
+  public async deleteById(@Param('id') id: string): Promise<string> {
+    await this.botService.deleteById(id);
+
+    return id;
+  }
+}

--- a/src/api/bot/bot.module.ts
+++ b/src/api/bot/bot.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Bot } from './entities';
+import { BotService } from './bot.service';
+import { BotController } from './bot.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Bot])],
+  controllers: [BotController],
+  providers: [BotService],
+  exports: [BotService],
+})
+export class BotModule {}

--- a/src/api/bot/bot.repository.ts
+++ b/src/api/bot/bot.repository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+
+import { Bot } from './entities/bot.entity';
+
+export class BotRepository extends Repository<Bot> {}

--- a/src/api/bot/bot.routes.ts
+++ b/src/api/bot/bot.routes.ts
@@ -1,0 +1,44 @@
+import { HttpStatus, RequestMethod } from '@nestjs/common';
+
+import { UserRole } from '@/common/enums';
+
+import { GotBotDto, CreatedBotDto } from './dto';
+
+import type { IRouteParams } from '@/decorators';
+
+export default {
+  index: 'bots',
+  create: <IRouteParams>{
+    path: '/',
+    code: HttpStatus.CREATED,
+    method: RequestMethod.POST,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [{ status: HttpStatus.CREATED, type: CreatedBotDto }],
+    },
+  },
+  getAll: <IRouteParams>{
+    path: '/:userId',
+    method: RequestMethod.GET,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [{ status: HttpStatus.OK, type: GotBotDto, isArray: true }],
+    },
+  },
+  deleteById: <IRouteParams>{
+    path: '/:id',
+    method: RequestMethod.DELETE,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [
+        {
+          status: HttpStatus.OK,
+          schema: {
+            type: 'string',
+            example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc',
+          },
+        },
+      ],
+    },
+  },
+};

--- a/src/api/bot/bot.service.spec.ts
+++ b/src/api/bot/bot.service.spec.ts
@@ -1,0 +1,111 @@
+import { omit } from 'ramda';
+import { Test } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+import { Bot } from './entities';
+import { CreateBotDto } from './dto';
+import { BotService } from './bot.service';
+import { BotRepository } from './bot.repository';
+
+import { Customer } from '../customer/entities';
+
+import type { DeepMocked } from '@golevelup/ts-jest';
+
+describe('BotService', () => {
+  let botService: BotService;
+  let botRepository: DeepMocked<BotRepository>;
+
+  const creator = {
+    bots: [],
+    id: 'creator 1',
+    name: 'creator 1',
+    password: 'password1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: 'test@example.com',
+  } as Customer;
+
+  const bots: Bot[] = [
+    {
+      creator,
+      id: '123',
+      name: 'test bot 1',
+      publishDate: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      creator,
+      id: '456',
+      name: 'test bot 2',
+      publishDate: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+  creator.bots = bots;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        BotService,
+        {
+          provide: getRepositoryToken(Bot),
+          useValue: {
+            save: jest.fn(),
+            create: jest.fn(),
+            findBy: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    })
+      .useMocker(createMock)
+      .compile();
+
+    botService = module.get(BotService);
+    botRepository = module.get(getRepositoryToken(Bot));
+  });
+
+  describe('create', () => {
+    it('should create a bot', async () => {
+      botRepository.create.mockReturnValueOnce(bots[0]);
+
+      const data: CreateBotDto = { creatorId: '123' };
+
+      const result = await botService.create(data);
+
+      expect(result).toEqual(omit(['creator'], bots[0]));
+      expect(botRepository.create).toHaveBeenCalled();
+      expect(botRepository.save).toHaveBeenCalled();
+      expect(botRepository.save.mock.calls[0][0]).toEqual(bots[0]);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should get all bots of user', async () => {
+      botRepository.findBy.mockResolvedValueOnce(bots);
+
+      const result = await botService.getAll('123');
+
+      expect(result).toEqual(bots);
+      expect(botRepository.findBy).toHaveBeenCalled();
+      expect(botRepository.findBy.mock.calls[0][0]).toEqual({
+        creator: { id: '123' },
+      });
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should delete the bot by id', async () => {
+      botRepository.delete.mockResolvedValueOnce('test value' as any);
+
+      const result = await botService.deleteById('123');
+
+      expect(result).toEqual('test value');
+      expect(botRepository.delete).toHaveBeenCalled();
+      expect(botRepository.delete.mock.calls[0][0]).toEqual({ id: '123' });
+    });
+  });
+});

--- a/src/api/bot/bot.service.ts
+++ b/src/api/bot/bot.service.ts
@@ -1,0 +1,44 @@
+import { omit } from 'ramda';
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { name } from '@/utils/helpers';
+
+import { Bot } from './entities';
+import { BotRepository } from './bot.repository';
+
+import type { DeleteResult } from 'typeorm';
+import type { GotBotDto, CreateBotDto, CreatedBotDto } from './dto';
+
+@Injectable()
+export class BotService {
+  constructor(
+    @InjectRepository(Bot)
+    private botRepository: BotRepository,
+  ) {}
+
+  // TODO: Validate current user is the creatorId
+  public async create(data: CreateBotDto): Promise<CreatedBotDto> {
+    const { creatorId } = data;
+
+    const createdBot = this.botRepository.create({
+      creator: { id: creatorId },
+      name: name.generateRandomName(),
+    });
+
+    await this.botRepository.save(createdBot);
+
+    return omit(['creator'], createdBot);
+  }
+
+  public async getAll(userId: string): Promise<GotBotDto[]> {
+    const bots = await this.botRepository.findBy({ creator: { id: userId } });
+
+    return bots;
+  }
+
+  public async deleteById(id: string): Promise<DeleteResult> {
+    return this.botRepository.delete({ id });
+  }
+}

--- a/src/api/bot/dto/create-bot.dto.ts
+++ b/src/api/bot/dto/create-bot.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class CreateBotDto {
+  @IsUUID()
+  @IsNotEmpty()
+  @ApiProperty({
+    format: 'uuid',
+    example: '15489892-ef5c-46ec-a2d8-ff5300808f87',
+  })
+  creatorId: string;
+}

--- a/src/api/bot/dto/created-bot.dto.ts
+++ b/src/api/bot/dto/created-bot.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ActionedBaseDto } from '@/common/dto';
+
+export class CreatedBotDto extends ActionedBaseDto {
+  @ApiProperty({ example: 'Lorem' })
+  name: string;
+
+  @ApiProperty({ format: 'date-time' })
+  publishDate: Date;
+}

--- a/src/api/bot/dto/got-bot.dto.ts
+++ b/src/api/bot/dto/got-bot.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ActionedBaseDto } from '@/common/dto';
+
+export class GotBotDto extends ActionedBaseDto {
+  @ApiProperty({ example: 'Lorem' })
+  name: string;
+
+  @ApiProperty({ format: 'date-time' })
+  publishDate: Date;
+}

--- a/src/api/bot/dto/index.ts
+++ b/src/api/bot/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './got-bot.dto';
+export * from './create-bot.dto';
+export * from './created-bot.dto';

--- a/src/api/bot/entities/bot.entity.ts
+++ b/src/api/bot/entities/bot.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+
+import { Customer } from '@/api/customer/entities';
+import { Base as BaseEntity } from '@/common/entities';
+
+@Entity({ name: 'bots' })
+export class Bot extends BaseEntity {
+  @Column()
+  name: string;
+
+  @ManyToOne(() => Customer, (customer) => customer.bots)
+  creator: Customer;
+
+  @Column({
+    name: 'publish_date',
+    type: 'timestamp',
+    nullable: true,
+  })
+  publishDate: Date;
+}

--- a/src/api/bot/entities/index.ts
+++ b/src/api/bot/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './bot.entity';

--- a/src/api/customer/entities/customer.entity.ts
+++ b/src/api/customer/entities/customer.entity.ts
@@ -1,13 +1,14 @@
 import { omit } from 'ramda';
 import { Exclude } from 'class-transformer';
 
-import { Column, Entity, BeforeInsert, BeforeUpdate } from 'typeorm';
+import { Column, Entity, BeforeInsert, BeforeUpdate, OneToMany } from 'typeorm';
 
 import { hash } from '@/utils/helpers';
 import { UserRole } from '@/common/enums';
 import { Base as BaseEntity } from '@/common/entities';
 
 import type { Token } from '@/api/token/entities';
+import { Bot } from '@/api/bot/entities/bot.entity';
 
 @Entity({ name: 'customers' })
 export class Customer extends BaseEntity {
@@ -20,6 +21,9 @@ export class Customer extends BaseEntity {
 
   @Column({ name: 'name' })
   name: string;
+
+  @OneToMany(() => Bot, (bot) => bot.creator)
+  bots: Bot[];
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 
 import { AppController } from './app.controller';
 
+import { BotModule } from '@/api/bot/bot.module';
 import { AuthModule } from '@/api/auth/auth.module';
 import { configuration, EnvSchema } from '@/config';
 import { TokenModule } from '@/api/token/token.module';
@@ -16,6 +17,7 @@ import { CustomerModule } from '@/api/customer/customer.module';
       validationSchema: EnvSchema,
       load: [configuration],
     }),
+    BotModule,
     AuthModule,
     TokenModule,
     AdminModule,

--- a/src/database/migrations/1708576746475-Bot.ts
+++ b/src/database/migrations/1708576746475-Bot.ts
@@ -1,0 +1,62 @@
+import {
+  Table,
+  QueryRunner,
+  TableForeignKey,
+  MigrationInterface,
+} from 'typeorm';
+
+export class Bot1708576746475 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'bots',
+        columns: [
+          {
+            name: 'id',
+            type: 'varchar',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+          },
+          {
+            name: 'creatorId',
+            type: 'varchar',
+          },
+          {
+            name: 'publish_date',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createForeignKey(
+      'bots',
+      new TableForeignKey({
+        columnNames: ['creatorId'],
+        referencedTableName: 'customers',
+        referencedColumnNames: ['id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('bots');
+  }
+}

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -1,6 +1,7 @@
 import { Env } from '@/utils/constants';
 
 import hash from './hash';
+import name from './name';
 import enumh from './enumh';
 import entity from './entity';
 
@@ -8,4 +9,4 @@ const getEnv = (): string => process.env.NODE_ENV || Env.DEVELOPMENT;
 
 const isDevelopmentEnv = (): boolean => getEnv() !== Env.PRODUCTION;
 
-export { getEnv, isDevelopmentEnv, hash, enumh, entity };
+export { getEnv, isDevelopmentEnv, hash, name, enumh, entity };

--- a/src/utils/helpers/name.ts
+++ b/src/utils/helpers/name.ts
@@ -1,0 +1,15 @@
+import {
+  animals,
+  adjectives,
+  uniqueNamesGenerator,
+} from '@joaomoreno/unique-names-generator';
+
+function generateRandomName(): string {
+  const randomName = uniqueNamesGenerator({
+    dictionaries: [adjectives, animals],
+  });
+
+  return randomName;
+}
+
+export default { generateRandomName };

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,6 +591,11 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+"@joaomoreno/unique-names-generator@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@joaomoreno/unique-names-generator/-/unique-names-generator-5.1.0.tgz#d577d425aed794c44c0e8863cddd5dea349f74f3"
+  integrity sha512-KEVThTpUIKPb7dBKJ9mJ3WYnD1mJZZsEinCSp9CVEPlWbDagurFv1RKRjvvujrLfJzsGc0HkBHS9W8Bughao4A==
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,6 +351,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@golevelup/ts-jest@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@golevelup/ts-jest/-/ts-jest-0.4.0.tgz#e36551ecbb37fcf3e4143a1ba9f78a649649dc91"
+  integrity sha512-ehgllV/xU8PC+yVyEUtTzhiSQKsr7k5Jz74B6dtCaVJz7/Vo7JiaACsCLvD7/iATlJUAEqvBson0OHewD3JDzQ==
+
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz"


### PR DESCRIPTION
### Tasks
- [Create chatbot API (metada only)](https://trello.com/c/UxwjFDUw)
- [Get chatbots pagination API](https://trello.com/c/pJEHClHh)

### Describe
- About the `create` API:
  - Create chatbot metadata (name, publish status) without touching the logic flows of studio
  - On create successfully, FE should show success modal
- About the `get` API:
  - Currently, just get all chatbots
  - If time support (or require) then add pagination later
- Add unit tests for chatbot APIs