### PR TITLE
Feat: Create card-type-field-type relationships

### DIFF
--- a/src/api/card-type-field-type/card-type-field-type.repository.ts
+++ b/src/api/card-type-field-type/card-type-field-type.repository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+
+import { CardTypeFieldType } from './entities';
+
+export class CardTypeFieldTypeRepository extends Repository<CardTypeFieldType> {}

--- a/src/api/card-type-field-type/card-type-field-type.service.ts
+++ b/src/api/card-type-field-type/card-type-field-type.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { CardTypeFieldType } from './entities';
+import { CardTypeFieldTypeRepository } from './card-type-field-type.repository';
+
+@Injectable()
+export class CardTypeFieldTypeService {
+  constructor(
+    @InjectRepository(CardTypeFieldType)
+    private cardTypeFieldTypeRepository: CardTypeFieldTypeRepository,
+  ) {}
+
+  public async create({
+    position,
+    cardTypeId,
+    fieldTypeId,
+  }: {
+    position: number;
+    cardTypeId: string;
+    fieldTypeId: string;
+  }) {
+    const createdDependency = this.cardTypeFieldTypeRepository.create({
+      position,
+      cardType: { id: cardTypeId },
+      fieldType: { id: fieldTypeId },
+    });
+
+    await this.cardTypeFieldTypeRepository.save(createdDependency);
+
+    return createdDependency;
+  }
+}

--- a/src/api/card-type-field-type/entities/card-type-field-type.entity.ts
+++ b/src/api/card-type-field-type/entities/card-type-field-type.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { CardType } from '@/api/card-type/entities';
+import { FieldType } from '@/api/field-type/entities';
+
+import { Base as BaseEntity } from '@/common/entities/base.entity';
+
+@Entity({ name: 'card_types_field_types' })
+export class CardTypeFieldType extends BaseEntity {
+  @Column()
+  position: number;
+
+  @ManyToOne(() => CardType)
+  @JoinColumn({ name: 'card_type_id' })
+  cardType: CardType;
+
+  @ManyToOne(() => FieldType)
+  @JoinColumn({ name: 'field_type_id' })
+  fieldType: FieldType;
+}

--- a/src/api/card-type-field-type/entities/index.ts
+++ b/src/api/card-type-field-type/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './card-type-field-type.entity';

--- a/src/api/card-type/card-type.service.ts
+++ b/src/api/card-type/card-type.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { CardType } from './entities';
 import { GotCardTypeDto } from './dto';
+import { CardTypeEnum } from './card-type.enum';
 import { CardTypeRepository } from './card-type.repository';
 
 @Injectable()
@@ -15,5 +16,11 @@ export class CardTypeService {
     const cardTypes = await this.cardTypeRepository.find();
 
     return cardTypes;
+  }
+
+  public async getByType(type: CardTypeEnum): Promise<GotCardTypeDto> {
+    const cardType = await this.cardTypeRepository.findOneBy({ type });
+
+    return cardType;
   }
 }

--- a/src/api/card-type/entities/card-type.entity.ts
+++ b/src/api/card-type/entities/card-type.entity.ts
@@ -1,9 +1,10 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 
 import { enumh } from '@/utils/helpers';
 import { Base as BaseEntity } from '@/common/entities';
 
 import { CardTypeEnum, GroupTypeEnum } from '../card-type.enum';
+import { CardTypeFieldType } from '@/api/card-type-field-type/entities';
 
 @Entity({ name: 'card_types' })
 export class CardType extends BaseEntity {
@@ -27,4 +28,10 @@ export class CardType extends BaseEntity {
     default: enumh.getFirstKey<typeof GroupTypeEnum>(GroupTypeEnum),
   })
   groupType: GroupTypeEnum;
+
+  @OneToMany(
+    () => CardTypeFieldType,
+    (cardTypeFieldType) => cardTypeFieldType.cardType,
+  )
+  cardTypesFieldTypes: CardTypeFieldType[];
 }

--- a/src/api/card/card.controller.ts
+++ b/src/api/card/card.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Param } from '@nestjs/common';
+
+import { InjectController, InjectRoute } from '@/decorators';
+
+import cardRoutes from './card.routes';
+import { CardService } from './card.service';
+import { CreateCardDto, CreatedCardDto, GotCardDto } from './dto';
+
+@InjectController({ name: cardRoutes.index })
+export class CardController {
+  constructor(private cardService: CardService) {}
+
+  @InjectRoute(cardRoutes.create)
+  public async createOne(@Body() data: CreateCardDto): Promise<CreatedCardDto> {
+    const createdCard = await this.cardService.create(data);
+
+    return createdCard;
+  }
+
+  @InjectRoute(cardRoutes.getAll)
+  public async getAll(@Param('nodeId') nodeId: string): Promise<GotCardDto[]> {
+    const cards = await this.cardService.getAll(nodeId);
+
+    return cards;
+  }
+}

--- a/src/api/card/card.module.ts
+++ b/src/api/card/card.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Card } from './entities';
+import { CardService } from './card.service';
+import { CardController } from './card.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Card])],
+  controllers: [CardController],
+  providers: [CardService],
+  exports: [CardService],
+})
+export class CardModule {}

--- a/src/api/card/card.repository.ts
+++ b/src/api/card/card.repository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+
+import { Card } from './entities';
+
+export class CardRepository extends Repository<Card> {}

--- a/src/api/card/card.routes.ts
+++ b/src/api/card/card.routes.ts
@@ -1,0 +1,27 @@
+import { HttpStatus, RequestMethod } from '@nestjs/common';
+
+import { UserRole } from '@/common/enums';
+import { IRouteParams } from '@/decorators';
+
+import { CreatedCardDto, GotCardDto } from './dto';
+
+export default {
+  index: 'cards',
+  create: <IRouteParams>{
+    path: '/',
+    code: HttpStatus.CREATED,
+    method: RequestMethod.POST,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [{ status: HttpStatus.CREATED, type: CreatedCardDto }],
+    },
+  },
+  getAll: <IRouteParams>{
+    path: '/:nodeId',
+    method: RequestMethod.GET,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [{ status: HttpStatus.OK, type: GotCardDto, isArray: true }],
+    },
+  },
+};

--- a/src/api/card/card.service.ts
+++ b/src/api/card/card.service.ts
@@ -1,0 +1,44 @@
+import { omit } from 'ramda';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Card } from './entities';
+import { CardRepository } from './card.repository';
+import { GotCardDto, CreateCardDto, CreatedCardDto } from './dto';
+
+@Injectable()
+export class CardService {
+  constructor(@InjectRepository(Card) private cardRepository: CardRepository) {}
+
+  public async create({
+    nodeId,
+    cardTypeId,
+  }: CreateCardDto): Promise<CreatedCardDto> {
+    const count = await this.cardRepository.count({
+      where: { node: { id: nodeId } },
+    });
+
+    const createdCard = this.cardRepository.create({
+      position: count,
+      node: { id: nodeId },
+      cardType: { id: cardTypeId },
+    });
+
+    await this.cardRepository.save(createdCard);
+
+    return { ...omit(['node', 'cardType'], createdCard), cardTypeId, nodeId };
+  }
+
+  public async getAll(nodeId: string): Promise<GotCardDto[]> {
+    const cards = await this.cardRepository.find({
+      where: { node: { id: nodeId } },
+      relations: { cardType: true },
+    });
+
+    return cards.map((card) => ({
+      ...card,
+      nodeId,
+      cardTypeId: card.cardType.id,
+    }));
+  }
+}

--- a/src/api/card/dto/create-card.dto.ts
+++ b/src/api/card/dto/create-card.dto.ts
@@ -1,0 +1,16 @@
+import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCardDto {
+  @IsUUID()
+  @ApiProperty({
+    example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc',
+  })
+  nodeId: string;
+
+  @IsUUID()
+  @ApiProperty({
+    example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc',
+  })
+  cardTypeId: string;
+}

--- a/src/api/card/dto/created-card.dto.ts
+++ b/src/api/card/dto/created-card.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ActionedBaseDto } from '@/common/dto';
+
+export class CreatedCardDto extends ActionedBaseDto {
+  @ApiProperty({ example: 0 })
+  position: number;
+
+  @ApiProperty({ format: 'uuid' })
+  nodeId: string;
+
+  @ApiProperty({ format: 'uuid' })
+  cardTypeId: string;
+}

--- a/src/api/card/dto/got-card.dto.ts
+++ b/src/api/card/dto/got-card.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ActionedBaseDto } from '@/common/dto';
+
+export class GotCardDto extends ActionedBaseDto {
+  @ApiProperty({ example: 0 })
+  position: number;
+
+  @ApiProperty({ format: 'uuid' })
+  nodeId: string;
+
+  @ApiProperty({ format: 'uuid' })
+  cardTypeId: string;
+}

--- a/src/api/card/dto/index.ts
+++ b/src/api/card/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './got-card.dto';
+export * from './create-card.dto';
+export * from './created-card.dto';

--- a/src/api/card/entities/card.entity.ts
+++ b/src/api/card/entities/card.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { Node } from '@/api/node/entities';
+import { CardType } from '@/api/card-type/entities';
+import { Base as BaseEntity } from '@/common/entities';
+
+@Entity({ name: 'cards' })
+export class Card extends BaseEntity {
+  @Column()
+  position: number;
+
+  @Column({ name: 'node_id' })
+  nodeId: string;
+
+  @Column({ name: 'card_type_id' })
+  cardTypeId: string;
+
+  @ManyToOne(() => Node, (node) => node.cards)
+  @JoinColumn({ name: 'node_id' })
+  node: Node;
+
+  @ManyToOne(() => CardType)
+  @JoinColumn({ name: 'card_type_id' })
+  cardType: CardType;
+}

--- a/src/api/card/entities/index.ts
+++ b/src/api/card/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './card.entity';

--- a/src/api/edge/dto/create-edge.dto.ts
+++ b/src/api/edge/dto/create-edge.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+
+export class CreateEdgeDto {
+  @IsUUID()
+  @IsOptional()
+  cardId: string;
+
+  @IsUUID()
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  sourceNodeId: string;
+
+  @IsUUID()
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  targetNodeId: string;
+}

--- a/src/api/edge/dto/created-edge.dto.ts
+++ b/src/api/edge/dto/created-edge.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreatedEdgeDto {
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  sourceNodeId: string;
+
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  targetNodeId: string;
+
+  @ApiProperty({ format: 'date-time' })
+  createdAt: Date;
+
+  @ApiProperty({ format: 'date-time' })
+  updatedAt: Date;
+}

--- a/src/api/edge/dto/got-edge.dto.ts
+++ b/src/api/edge/dto/got-edge.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GotEdgeDto {
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  cardId: string;
+
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  sourceNodeId: string;
+
+  @ApiProperty({ example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc' })
+  targetNodeId: string;
+
+  @ApiProperty({ format: 'date-time' })
+  createdAt: Date;
+
+  @ApiProperty({ format: 'date-time' })
+  updatedAt: Date;
+}

--- a/src/api/edge/dto/index.ts
+++ b/src/api/edge/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './got-edge.dto';
+export * from './create-edge.dto';
+export * from './created-edge.dto';

--- a/src/api/edge/edge.controller.ts
+++ b/src/api/edge/edge.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Param, Query } from '@nestjs/common';
+
+import { InjectController, InjectRoute } from '@/decorators';
+
+import { Type } from './enums';
+import { Edge } from './entities';
+import edgeRoutes from './edge.routes';
+import { EdgeService } from './edge.service';
+import { CreateEdgeDto, CreatedEdgeDto } from './dto';
+
+@InjectController({ name: edgeRoutes.index })
+export class EdgeController {
+  constructor(private edgeService: EdgeService) {}
+
+  @InjectRoute(edgeRoutes.createOrUpdate)
+  public async createOrUpdate(
+    @Body() data: CreateEdgeDto,
+  ): Promise<CreatedEdgeDto> {
+    const createdEdge = await this.edgeService.createOrUpdate(data);
+
+    return createdEdge;
+  }
+
+  @InjectRoute(edgeRoutes.getByCardOrNodeId)
+  public async getByCardOrNodeId(
+    @Param('id') id: string,
+    @Query('type') type: Type,
+  ): Promise<Edge> {
+    const edge = await this.edgeService.getByCardOrNodeId(id, type);
+
+    return edge;
+  }
+}

--- a/src/api/edge/edge.module.ts
+++ b/src/api/edge/edge.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Edge } from './entities';
+import { EdgeService } from './edge.service';
+import { EdgeController } from './edge.controller';
+
+import { NodeModule } from '../node/node.module';
+
+@Module({
+  imports: [NodeModule, TypeOrmModule.forFeature([Edge])],
+  controllers: [EdgeController],
+  providers: [EdgeService],
+  exports: [EdgeService],
+})
+export class EdgeModule {}

--- a/src/api/edge/edge.repository.ts
+++ b/src/api/edge/edge.repository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+
+import { Edge } from './entities';
+
+export class EdgeRepository extends Repository<Edge> {}

--- a/src/api/edge/edge.routes.ts
+++ b/src/api/edge/edge.routes.ts
@@ -1,0 +1,26 @@
+import { HttpStatus, RequestMethod } from '@nestjs/common';
+
+import { UserRole } from '@/common/enums';
+import { IRouteParams } from '@/decorators';
+
+import { CreatedEdgeDto, GotEdgeDto } from './dto';
+
+export default {
+  index: 'edges',
+  createOrUpdate: <IRouteParams>{
+    path: '/',
+    method: RequestMethod.POST,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [{ status: HttpStatus.CREATED, type: CreatedEdgeDto }],
+    },
+  },
+  getByCardOrNodeId: <IRouteParams>{
+    path: '/:id',
+    method: RequestMethod.GET,
+    roles: [UserRole.CUSTOMER],
+    swaggerInfo: {
+      responses: [{ status: HttpStatus.OK, type: GotEdgeDto }],
+    },
+  },
+};

--- a/src/api/edge/edge.service.ts
+++ b/src/api/edge/edge.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Type } from './enums';
+import { Edge } from './entities';
+import { EdgeRepository } from './edge.repository';
+import { CreateEdgeDto, CreatedEdgeDto } from './dto';
+
+import { NodeService } from '../node/node.service';
+
+@Injectable()
+export class EdgeService {
+  constructor(
+    @InjectRepository(Edge) private edgeRepository: EdgeRepository,
+    private nodeService: NodeService,
+  ) {}
+
+  public async createOrUpdate(data: CreateEdgeDto): Promise<CreatedEdgeDto> {
+    if (!data.cardId) {
+      await this.edgeRepository.delete({
+        sourceNodeId: data.sourceNodeId,
+      });
+      await this.edgeRepository.delete({
+        targetNodeId: data.targetNodeId,
+      });
+    } else {
+      await this.edgeRepository.delete({ card: { id: data.cardId } });
+    }
+
+    const createdEdge = this.edgeRepository.create({
+      card: { id: data.cardId },
+      sourceNodeId: data.sourceNodeId,
+      targetNodeId: data.targetNodeId,
+    });
+
+    const { createdAt, updatedAt } = await this.edgeRepository.save(
+      createdEdge,
+    );
+
+    return {
+      ...data,
+      createdAt,
+      updatedAt,
+    };
+  }
+
+  public async getByCardOrNodeId(id: string, type: Type): Promise<Edge> {
+    const condition =
+      type === Type.CARD
+        ? { card: { id } }
+        : [{ sourceNodeId: id }, { targetNodeId: id }];
+
+    const edge = await this.edgeRepository.findOne({
+      where: condition,
+      relations: { card: true },
+    });
+
+    return edge;
+  }
+}

--- a/src/api/edge/entities/edge.entity.ts
+++ b/src/api/edge/entities/edge.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  OneToOne,
+  ManyToOne,
+  JoinColumn,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { Card } from '@/api/card/entities';
+import { Node } from '@/api/node/entities';
+import { Base as BaseEntity } from '@/common/entities';
+
+@Entity({ name: 'edges' })
+export class Edge extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid', { name: 'source_node_id' })
+  sourceNodeId: string;
+
+  @PrimaryGeneratedColumn('uuid', { name: 'target_node_id' })
+  targetNodeId: string;
+
+  @ManyToOne(() => Node, (node) => node.sourceNodeToEdge)
+  @JoinColumn({ name: 'source_node_id' })
+  sourceNode: Node;
+
+  @ManyToOne(() => Node, (node) => node.targetNodeToEdge)
+  @JoinColumn({ name: 'target_node_id' })
+  targetNode: Node;
+
+  @OneToOne(() => Card)
+  @JoinColumn({ name: 'card_id' })
+  card: Card;
+}

--- a/src/api/edge/entities/index.ts
+++ b/src/api/edge/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './edge.entity';

--- a/src/api/edge/enums/edge.enum.ts
+++ b/src/api/edge/enums/edge.enum.ts
@@ -1,0 +1,4 @@
+export enum Type {
+  CARD = 'CARD',
+  NODE = 'NODE',
+}

--- a/src/api/edge/enums/index.ts
+++ b/src/api/edge/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './edge.enum';

--- a/src/api/field-type/dto/got-field-type.dto.ts
+++ b/src/api/field-type/dto/got-field-type.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { enumh } from '@/utils/helpers';
+import { ActionedBaseDto } from '@/common/dto';
+
+import { FieldTypeEnum } from '../field-type.enum';
+
+export class GotFieldTypeDto extends ActionedBaseDto {
+  @ApiProperty({
+    enum: FieldTypeEnum,
+    default: enumh.getFirstKey<typeof FieldTypeEnum>(FieldTypeEnum),
+  })
+  type: FieldTypeEnum;
+
+  @ApiProperty({ example: 'Lorem' })
+  question: string;
+}

--- a/src/api/field-type/dto/index.ts
+++ b/src/api/field-type/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './got-field-type.dto';

--- a/src/api/field-type/entities/field-type.entity.ts
+++ b/src/api/field-type/entities/field-type.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, OneToMany } from 'typeorm';
+
+import { enumh } from '@/utils/helpers';
+import { Base as BaseEntity } from '@/common/entities';
+import { CardTypeFieldType } from '@/api/card-type-field-type/entities';
+
+import { FieldTypeEnum } from '../field-type.enum';
+
+@Entity({ name: 'field_types' })
+export class FieldType extends BaseEntity {
+  @Column({
+    type: 'enum',
+    enum: FieldTypeEnum,
+    default: enumh.getFirstKey<typeof FieldTypeEnum>(FieldTypeEnum),
+  })
+  type: FieldTypeEnum;
+
+  @Column()
+  question: string;
+
+  @OneToMany(
+    () => CardTypeFieldType,
+    (cardTypeFieldType) => cardTypeFieldType.fieldType,
+  )
+  cardTypesFieldTypes: CardTypeFieldType[];
+}

--- a/src/api/field-type/entities/index.ts
+++ b/src/api/field-type/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './field-type.entity';

--- a/src/api/field-type/field-type.enum.ts
+++ b/src/api/field-type/field-type.enum.ts
@@ -1,0 +1,4 @@
+export enum FieldTypeEnum {
+  LABEL = 'LABEL',
+  CONDITION = 'CONDITION',
+}

--- a/src/api/field-type/field-type.module.ts
+++ b/src/api/field-type/field-type.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { FieldType } from './entities';
+import { FieldTypeService } from './field-type.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FieldType])],
+  controllers: [],
+  providers: [FieldTypeService],
+  exports: [FieldTypeService],
+})
+export class FieldTypeModule {}

--- a/src/api/field-type/field-type.repository.ts
+++ b/src/api/field-type/field-type.repository.ts
@@ -1,0 +1,5 @@
+import { Repository } from 'typeorm';
+
+import { FieldType } from './entities';
+
+export class FieldTypeRepository extends Repository<FieldType> {}

--- a/src/api/field-type/field-type.service.ts
+++ b/src/api/field-type/field-type.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { FieldType } from './entities';
+import { GotFieldTypeDto } from './dto';
+import { FieldTypeEnum } from './field-type.enum';
+import { FieldTypeRepository } from './field-type.repository';
+
+@Injectable()
+export class FieldTypeService {
+  constructor(
+    @InjectRepository(FieldType)
+    private fieldTypeRepository: FieldTypeRepository,
+  ) {}
+
+  public async getByType(type: FieldTypeEnum): Promise<GotFieldTypeDto> {
+    const fieldType = await this.fieldTypeRepository.findOneBy({ type });
+
+    return fieldType;
+  }
+}

--- a/src/api/node/dto/create-node.dto.ts
+++ b/src/api/node/dto/create-node.dto.ts
@@ -1,10 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNumber, IsUUID } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsUUID } from 'class-validator';
 
 import { enumh } from '@/utils/helpers';
 import { NodeTypeEnum } from '@/api/node-type/enums';
 
 export class CreateNodeDto {
+  @IsUUID()
+  @IsOptional()
+  @ApiProperty({
+    example: '353d6e1a-492b-40b1-be6e-2a08d7f782dc',
+  })
+  id?: string;
+
   @IsEnum(NodeTypeEnum)
   @ApiProperty({
     enum: NodeTypeEnum,

--- a/src/api/node/entities/node.entity.ts
+++ b/src/api/node/entities/node.entity.ts
@@ -1,5 +1,7 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
 
+import { Card } from '@/api/card/entities';
+import { Edge } from '@/api/edge/entities';
 import { Flow } from '@/api/flow/entities';
 import { NodeType } from '@/api/node-type/entities';
 import { Base as BaseEntity } from '@/common/entities';
@@ -24,4 +26,13 @@ export class Node extends BaseEntity {
   @ManyToOne(() => NodeType)
   @JoinColumn({ name: 'node_type_id' })
   nodeType: NodeType;
+
+  @OneToMany(() => Card, (card) => card.node)
+  cards: Card[];
+
+  @OneToMany(() => Edge, (edge) => edge.sourceNode)
+  sourceNodeToEdge: Edge[];
+
+  @OneToMany(() => Edge, (edge) => edge.targetNode)
+  targetNodeToEdge: Edge[];
 }

--- a/src/api/node/node.service.ts
+++ b/src/api/node/node.service.ts
@@ -61,7 +61,8 @@ export class NodeService {
       nodeType,
       x: data.x,
       y: data.y,
-      position: -1,
+      id: data.id,
+      position: -1, // TODO: Change position
       name: DEFAULT_NODE_NAME,
     });
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,8 @@ import { AppController } from './app.controller';
 
 import { BotModule } from '@/api/bot/bot.module';
 import { AuthModule } from '@/api/auth/auth.module';
+import { CardModule } from '@/api/card/card.module';
+import { EdgeModule } from '@/api/edge/edge.module';
 import { FlowModule } from '@/api/flow/flow.module';
 import { NodeModule } from '@/api/node/node.module';
 import { configuration, EnvSchema } from '@/config';
@@ -23,6 +25,8 @@ import { FlowTypeModule } from '@/api/flow-type/flow-type.module';
     }),
     BotModule,
     AuthModule,
+    CardModule,
+    EdgeModule,
     FlowModule,
     NodeModule,
     TokenModule,

--- a/src/database/migrations/1709697123087-FieldType.ts
+++ b/src/database/migrations/1709697123087-FieldType.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+import { enumh } from '@/utils/helpers';
+import { FieldTypeEnum } from '@/api/field-type/field-type.enum';
+
+export class FieldType1709697123087 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'field_types',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'type',
+            type: 'enum',
+            isUnique: true,
+            enum: enumh.getValuesAndToString<typeof FieldTypeEnum>(
+              FieldTypeEnum,
+            ),
+            enumName: 'field_types_type_enum',
+          },
+          {
+            name: 'question',
+            type: 'varchar',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('field_types');
+    await queryRunner.query('DROP TYPE field_types_type_enum');
+  }
+}

--- a/src/database/migrations/1709698734131-CardTypeFieldType.ts
+++ b/src/database/migrations/1709698734131-CardTypeFieldType.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CardTypeFieldType1709698734131 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'card_types_field_types',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'position',
+            type: 'int',
+          },
+          {
+            name: 'card_type_id',
+            type: 'uuid',
+          },
+          {
+            name: 'field_type_id',
+            type: 'uuid',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['card_type_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'card_types',
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['field_type_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'field_types',
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('card_types_field_types');
+  }
+}

--- a/src/database/migrations/1709708129776-Card.ts
+++ b/src/database/migrations/1709708129776-Card.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class Card1709708129776 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'cards',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'position',
+            type: 'int',
+          },
+          {
+            name: 'node_id',
+            type: 'uuid',
+          },
+          {
+            name: 'card_type_id',
+            type: 'uuid',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['node_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'nodes',
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['card_type_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'card_types',
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('cards');
+  }
+}

--- a/src/database/migrations/1709708130023-Edge.ts
+++ b/src/database/migrations/1709708130023-Edge.ts
@@ -1,0 +1,74 @@
+import { Table, QueryRunner, TableUnique, MigrationInterface } from 'typeorm';
+
+export class Edge1709708130023 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'edges',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'card_id',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'source_node_id',
+            type: 'uuid',
+          },
+          {
+            name: 'target_node_id',
+            type: 'uuid',
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: `('now'::text)::timestamp(6) with time zone`,
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['card_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'cards',
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['source_node_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'nodes',
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['target_node_id'],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'nodes',
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createUniqueConstraint(
+      'edges',
+      new TableUnique({
+        columnNames: ['card_id', 'source_node_id', 'target_node_id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('edges');
+  }
+}

--- a/src/database/seeds/card-type-field-type/card-type-field-type-seed.module.ts
+++ b/src/database/seeds/card-type-field-type/card-type-field-type-seed.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CardTypeModule } from '@/api/card-type/card-type.module';
+import { FieldTypeModule } from '@/api/field-type/field-type.module';
+import { CardTypeFieldType } from '@/api/card-type-field-type/entities';
+
+import { CardTypeFieldTypeSeedService } from './card-type-field-type-seed.service';
+
+@Module({
+  imports: [
+    CardTypeModule,
+    FieldTypeModule,
+    TypeOrmModule.forFeature([CardTypeFieldType]),
+  ],
+  providers: [CardTypeFieldTypeSeedService],
+})
+export class CardTypeFieldTypeSeedModule {}

--- a/src/database/seeds/card-type-field-type/card-type-field-type-seed.service.ts
+++ b/src/database/seeds/card-type-field-type/card-type-field-type-seed.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { CardTypeEnum } from '@/api/card-type/card-type.enum';
+import { FieldTypeEnum } from '@/api/field-type/field-type.enum';
+import { CardTypeService } from '@/api/card-type/card-type.service';
+import { FieldTypeService } from '@/api/field-type/field-type.service';
+import { CardTypeFieldType } from '@/api/card-type-field-type/entities';
+import { CardTypeFieldTypeRepository } from '@/api/card-type-field-type/card-type-field-type.repository';
+
+@Injectable()
+export class CardTypeFieldTypeSeedService {
+  constructor(
+    @InjectRepository(CardTypeFieldType)
+    private cardTypeService: CardTypeService,
+    private fieldTypeService: FieldTypeService,
+    private repository: CardTypeFieldTypeRepository,
+  ) {}
+
+  async seedExpressionCardFields() {
+    const countFieldType = await this.repository.count({
+      where: { cardType: { type: CardTypeEnum.EXPRESSION } },
+    });
+
+    if (!countFieldType) {
+      const expressionCardType = await this.cardTypeService.getByType(
+        CardTypeEnum.EXPRESSION,
+      );
+      const labelFieldType = await this.fieldTypeService.getByType(
+        FieldTypeEnum.LABEL,
+      );
+      const conditionFieldType = await this.fieldTypeService.getByType(
+        FieldTypeEnum.CONDITION,
+      );
+
+      await this.repository.save(
+        this.repository.create([
+          {
+            position: 0,
+            fieldType: { id: labelFieldType.id },
+            cardType: { id: expressionCardType.id },
+          },
+          {
+            position: 1,
+            cardType: { id: expressionCardType.id },
+            fieldType: { id: conditionFieldType.id },
+          },
+        ]),
+      );
+    }
+  }
+
+  async run() {
+    await this.seedExpressionCardFields();
+  }
+}

--- a/src/database/seeds/card-type-field-type/card-type-field-type-seed.service.ts
+++ b/src/database/seeds/card-type-field-type/card-type-field-type-seed.service.ts
@@ -12,9 +12,9 @@ import { CardTypeFieldTypeRepository } from '@/api/card-type-field-type/card-typ
 export class CardTypeFieldTypeSeedService {
   constructor(
     @InjectRepository(CardTypeFieldType)
+    private repository: CardTypeFieldTypeRepository,
     private cardTypeService: CardTypeService,
     private fieldTypeService: FieldTypeService,
-    private repository: CardTypeFieldTypeRepository,
   ) {}
 
   async seedExpressionCardFields() {

--- a/src/database/seeds/field-type/field-type-seed.module.ts
+++ b/src/database/seeds/field-type/field-type-seed.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { FieldType } from '@/api/field-type/entities';
+
+import { FieldTypeSeedService } from './field-type-seed.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FieldType])],
+  providers: [FieldTypeSeedService],
+})
+export class FieldTypeSeedModule {}

--- a/src/database/seeds/field-type/field-type-seed.service.ts
+++ b/src/database/seeds/field-type/field-type-seed.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { FieldType } from '@/api/field-type/entities';
+import { FieldTypeEnum } from '@/api/field-type/field-type.enum';
+import { FieldTypeRepository } from '@/api/field-type/field-type.repository';
+
+@Injectable()
+export class FieldTypeSeedService {
+  constructor(
+    @InjectRepository(FieldType) private repository: FieldTypeRepository,
+  ) {}
+
+  async seedLabelFieldType() {
+    const countFieldType = await this.repository.count({
+      where: { type: FieldTypeEnum.LABEL },
+    });
+
+    if (!countFieldType) {
+      await this.repository.save(
+        this.repository.create([
+          {
+            type: FieldTypeEnum.LABEL,
+            question: 'Label',
+          },
+          {
+            type: FieldTypeEnum.CONDITION,
+            question: 'Condition',
+          },
+        ]),
+      );
+    }
+  }
+
+  async run() {
+    await this.seedLabelFieldType();
+  }
+}

--- a/src/database/seeds/run-seed.ts
+++ b/src/database/seeds/run-seed.ts
@@ -5,7 +5,9 @@ import { AdminSeedService } from './admin/admin-seed.service';
 import { CardTypeSeedService } from './card-type/card-type-seed.service';
 import { FlowTypeSeedService } from './flow-type/flow-type-seed.service';
 import { NodeTypeSeedService } from './node-type/node-type-seed.service';
+import { FieldTypeSeedService } from './field-type/field-type-seed.service';
 import { FlowTypeNodeTypeSeedService } from './flow-type-node-type/flow-type-node-type-seed.service';
+import { CardTypeFieldTypeSeedService } from './card-type-field-type/card-type-field-type-seed.service';
 
 const runSeed = async () => {
   const app = await NestFactory.create(SeedModule);
@@ -14,7 +16,9 @@ const runSeed = async () => {
   await app.get(CardTypeSeedService).run();
   await app.get(FlowTypeSeedService).run();
   await app.get(NodeTypeSeedService).run();
+  await app.get(FieldTypeSeedService).run();
   await app.get(FlowTypeNodeTypeSeedService).run();
+  await app.get(CardTypeFieldTypeSeedService).run();
 
   app.close();
 };

--- a/src/database/seeds/seed.module.ts
+++ b/src/database/seeds/seed.module.ts
@@ -8,7 +8,9 @@ import { AdminSeedModule } from './admin/admin-seed.module';
 import { CardTypeSeedModule } from './card-type/card-type-seed.module';
 import { FlowTypeSeedModule } from './flow-type/flow-type-seed.module';
 import { NodeTypeSeedModule } from './node-type/node-type-seed.module';
+import { FieldTypeSeedModule } from './field-type/field-type-seed.module';
 import { FlowTypeNodeTypeSeedModule } from './flow-type-node-type/flow-type-node-type-seed.module';
+import { CardTypeFieldTypeSeedModule } from './card-type-field-type/card-type-field-type-seed.module';
 
 @Module({
   imports: [
@@ -25,7 +27,9 @@ import { FlowTypeNodeTypeSeedModule } from './flow-type-node-type/flow-type-node
     CardTypeSeedModule,
     FlowTypeSeedModule,
     NodeTypeSeedModule,
+    FieldTypeSeedModule,
     FlowTypeNodeTypeSeedModule,
+    CardTypeFieldTypeSeedModule,
   ],
 })
 export class SeedModule {}


### PR DESCRIPTION
### Tasks
- [Create Card API](https://trello.com/c/3AqbqHf7)

### Describe
- Create `FieldType` migration
- Create `FieldType` entity
- Create `FieldType` seed
- Create `CardTypeFieldType` migration
- Create `CardTypeFieldType` entity
- Create `CardTypeFieldType` seed
- Handle relationships between `CardType`, `FieldType`, and `CardTypeFieldType`
